### PR TITLE
Usage and VS2017 optimization fixes

### DIFF
--- a/containers/vqueue.impl.c
+++ b/containers/vqueue.impl.c
@@ -73,7 +73,7 @@ vqueue_t vqueue_create(void* buffer, int node_count)
 	queue->free_list.entire = 0;
 	queue->nodes = (vqueue_node_t*)(queue + 1);
 
-	/* Link nodes together, buffer was allocted with (node_count + 1)  so the last index is node_count */
+	/* Link nodes together, buffer was allocated with (node_count + 1) so the last index is node_count */
 	for (int i = 0; i < node_count; ++i)
 	{
 		queue->nodes[i].next.part.index = i + 1;


### PR DESCRIPTION
2 changes:
 - Allocate one more node so that the total amount of node we can push match what the user wants

 - With visual studio O2 settings, without the volatile key word the read/copy does not happen when we request it but is optimized to happen when needed. In the case of the pop, one of problem is that the "if (head.entire == queue->head.entire)" get optimized away (same for the push). 

The final disassembly show more instruction, but does not lead to a crash due to reads not happening at the right time (in our case the crash happened because the next index was read/copied only when getting the data pointer, with multiple thread running the code at the same time the index was invalid)

Before:
![pop_before](https://user-images.githubusercontent.com/388059/28756385-c81453c6-7532-11e7-9b94-c24495291f50.PNG)

After: 
![pop_after](https://user-images.githubusercontent.com/388059/28756387-cd8111be-7532-11e7-972b-3a9c6125dc52.PNG)
